### PR TITLE
add a mangler to enable adding headers on requests

### DIFF
--- a/v2/interface.go
+++ b/v2/interface.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"crypto/tls"
+	"net/http"
 )
 
 // AuthConfig is a union-type representing the possible auth configurations a
@@ -81,6 +82,8 @@ func DefaultClientConfiguration() *ClientConfiguration {
 		EnableAlphaFeatures: false,
 	}
 }
+
+type MangleRequestFunc func(request *http.Request) *http.Request
 
 // Client defines the interface to the v2 Open Service Broker client.  The
 // logical lifecycle of client operations is:
@@ -184,6 +187,10 @@ type Client interface {
 	// binding endpoint
 	// (/v2/service_instances/instance-id/service_bindings/binding-id)
 	GetBinding(r *GetBindingRequest) (*GetBindingResponse, error)
+
+	// MangleRequest allows a user to inspect/modify a request object just before
+	// it is actually used.
+	SetMangleRequest(mangler MangleRequestFunc)
 }
 
 // CreateFunc allows control over which implementation of a Client is


### PR DESCRIPTION
Hi,

We use the Open Service Broker API in one of our projects. We consume this API using this client library. In our case, we would like to add some headers to the requests created by the OSB client. Mainly, our use case is to add these header for tracing purposes. To trace a request that propagates to different microservices running in different services, tracing frameworks like opentracing add headers to requests. Currently, there is no way to add headers to the requests created by this client. This PR introduces such ability.

Thanks!