### PR TITLE
Added support for the following 2.15 Plan fields:

### DIFF
--- a/get_catalog_test.go
+++ b/get_catalog_test.go
@@ -213,6 +213,41 @@ func schemaCatalogResponse() *CatalogResponse {
 	return catalog
 }
 
+const okCatalog215Bytes = `{
+  "services": [{
+    "name": "fake-service-2",
+    "id": "fake-service-2-id",
+    "description": "service-description-2",
+    "bindable": false,
+    "plans": [{
+      "name": "fake-plan-2",
+      "id": "fake-plan-2-id",
+      "description": "description-2",
+      "bindable": true,
+      "plan_updateable": true,
+      "maximum_polling_duration": 600,
+      "maintenance_info": {
+        "version": "1.2.3",
+        "description": "Avast! Pieces o' madness are forever clear."
+      }
+    }]
+  }]
+}`
+
+func okCatalog215Response() *CatalogResponse {
+	response := okCatalog2Response()
+	var duration int64 = 600
+	response.Services[0].Plans[0].MaximumPollingDuration = &duration
+
+	response.Services[0].Plans[0].PlanUpdateable = truePtr()
+	response.Services[0].Plans[0].MaintenanceInfo = &MaintenanceInfo{
+		Version:     "1.2.3",
+		Description: "Avast! Pieces o' madness are forever clear.",
+	}
+
+	return response
+}
+
 func TestGetCatalog(t *testing.T) {
 	cases := []struct {
 		name               string
@@ -287,6 +322,26 @@ func TestGetCatalog(t *testing.T) {
 				body:   schemaCatalogBytes,
 			},
 			expectedResponse: okCatalogResponse(),
+		},
+		{
+			name:        "plan has its own updateable attribute, max polling duration and maintenance info",
+			version:     LatestAPIVersion(),
+			enableAlpha: true,
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   okCatalog215Bytes,
+			},
+			expectedResponse: okCatalog215Response(),
+		},
+		{
+			name:        "alpha disabled: plan has its own updateable attribute, max polling duration and maintenance info",
+			version:     LatestAPIVersion(),
+			enableAlpha: false,
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   okCatalog215Bytes,
+			},
+			expectedResponse: okCatalog2Response(),
 		},
 	}
 

--- a/types.go
+++ b/types.go
@@ -114,6 +114,30 @@ type Plan struct {
 	// the expected parameters for creation and update of instances and
 	// creation of bindings.
 	Schemas *Schemas `json:"schemas,omitempty"`
+	//PlanUpdateable requires alpha features flag to be enabled.
+	//
+	// PlanUpdateable specifies whether the Plan supports
+	// upgrade/downgrade/sidegrade to another version. If specified,
+	// this takes precedence over the Service Offering's PlanUpdateable
+	// field. Optional;
+	// defaults to unset
+	PlanUpdateable *bool `json:"plan_updateable,omitempty"`
+	// MaximumPollingDuration requires alpha features flag to be enabled.
+	//
+	// MaximumPollingDuration is a duration, in seconds, that the should
+	// be used as the Service's maximum polling duration.
+	MaximumPollingDuration *int64 `json:"maximum_polling_duration,omitempty"`
+	// MaintenanceInfo requires alpha features flag to be enabled.
+	//
+	// MaintenanceInfo represents maintenance information for a Service
+	// Instance which is provisioned using the Service Plan. Optional;
+	// defaults to unset
+	MaintenanceInfo *MaintenanceInfo `json:"maintenance_info,omitempty"`
+}
+
+type MaintenanceInfo struct {
+	Version     string `json:"version"`
+	Description string `json:"description,omitempty"`
 }
 
 // Schemas requires a client API version >=2.13.

--- a/version.go
+++ b/version.go
@@ -38,6 +38,10 @@ func (v APIVersion) String() string {
 	return v.label
 }
 
+func (v APIVersion) IsLessThan(other APIVersion) bool {
+	return !v.AtLeast(other)
+}
+
 // LatestAPIVersion returns the latest supported API version in the current
 // release of this library.
 func LatestAPIVersion() APIVersion {

--- a/version_test.go
+++ b/version_test.go
@@ -33,6 +33,23 @@ func TestAtLeast(t *testing.T) {
 	}
 }
 
+func TestIsLessThan(t *testing.T) {
+	v2_13 := Version2_13()
+	v2_12 := Version2_12()
+
+	if v2_13.IsLessThan(v2_12) {
+		t.Error("Expected 2.13 not to be less than 2.12")
+	}
+
+	if v2_13.IsLessThan(v2_13) {
+		t.Error("Expected 2.13 not to be less than itself")
+	}
+
+	if !v2_12.IsLessThan(v2_13) {
+		t.Error("Expected 2.12 to be less than 2.13")
+	}
+}
+
 func TestLatestAPIVersion(t *testing.T) {
 	if LatestAPIVersion() != Version2_14() {
 		t.Error("Unexpected Latest API Version--expected 2.14")


### PR DESCRIPTION
- plan_updateable
- maximum_polling_duration
- maintenance_info

Part of the 2.15 support #161 