### PR TITLE
Fix: Route from BindRequest not passed on

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -82,7 +82,7 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 			requestBody.BindResource[bindResourceAppGUIDKey] = *r.BindResource.AppGUID
 		}
 		if r.BindResource.Route != nil {
-			requestBody.BindResource[bindResourceRouteKey] = *r.BindResource.AppGUID
+			requestBody.BindResource[bindResourceRouteKey] = *r.BindResource.Route
 		}
 	}
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -147,7 +147,7 @@ func optionalFieldsBindRequest() *BindRequest {
 	return r
 }
 
-const optionalFieldsBindRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id","parameters":{"blu":2,"foo":"bar"},"bind_resource":{"app_guid":"test-app-guid","route":"test-app-guid"}}`
+const optionalFieldsBindRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id","parameters":{"blu":2,"foo":"bar"},"bind_resource":{"app_guid":"test-app-guid","route":"test-route"}}`
 
 func contextBindRequest() *BindRequest {
 	r := defaultBindRequest()


### PR DESCRIPTION
If there is a Route in the Bind Request then put it into the map instead of AppGUID again.